### PR TITLE
bulletproof termination after set amount of time [ of inactivity ]

### DIFF
--- a/scanner.c
+++ b/scanner.c
@@ -13,7 +13,6 @@
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
 #include <time.h>
-#include <poll.h>
 
 struct hci_request ble_hci_request(uint16_t ocf, int clen, void * status, void * cparam)
 {
@@ -153,13 +152,10 @@ int main()
 					info = (le_advertising_info *)offset;
 					char addr[18];
 					ba2str( &(info->bdaddr), addr);
-					if ( info->data[0] == 0x1e && info->data[1] == 0xff )
-					{
-	                    			printf("%s %d", addr, (int8_t)info->data[info->length]);
-						printf(" %d", info->length );
-        	            			for ( int i = 0; i < info->length; i++ ) printf( " %02X", (unsigned char) info->data[i] );
-					}
-		                    	printf("\n");
+					printf("%s %d", addr, (int8_t)info->data[info->length]);
+					for (int i = 0; i < info->length; i++)
+						printf(" %02X", (unsigned char)info->data[i]);
+					printf("\n");
 					offset = info->data + info->length + 2;
 				}
 			}

--- a/scanner.c
+++ b/scanner.c
@@ -147,7 +147,7 @@ int main()
 	int len;
 	int count = 0;
 
-	const int timeout = 30;
+	const int timeout = 10;
 	const int reset_timeout = 1; // wether to reset the timer on a received scan event (continuous scanning)
 	const int max_count = 1000;
 


### PR DESCRIPTION
Implemented a new method to make sure that the program is terminated after a set amount of time has passed. It works by setting a timer via alert() and it should be bulletproof under all conditions.

Also adds the ability to choose between continuous and non-continuous scanning. In non-continuous mode it will terminate when the time is up while in continuous mode it will reset the timer every time a beacon is detected. The timer can also be disabled by setting the timeout <= 0.
